### PR TITLE
Added a check to make sure the user exists before switching

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * ownCloud - impersonate
  *
@@ -20,32 +20,34 @@ use OCP\IUserSession;
 
 class SettingsController extends Controller {
 
-    /**
-     * @var IUserManager
-     */
-    private $userManager;
-    /**
-     * @var IUserSession
-     */
-    private $userSession;
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
+	/**
+	 * @var IUserSession
+	 */
+	private $userSession;
 
-    public function __construct($appName, IRequest $request, IUserManager $userManager, IUserSession $userSession){
-        parent::__construct($appName, $request);
-        $this->userManager = $userManager;
-        $this->userSession = $userSession;
-    }
+	public function __construct($appName, IRequest $request, IUserManager $userManager, IUserSession $userSession) {
+		parent::__construct($appName, $request);
+		$this->userManager = $userManager;
+		$this->userSession = $userSession;
+	}
 
-
-
-    /**
-     * become another user
-     * @UseSession
-     */
-    public function impersonate($userid) {
-        $user = $this->userManager->get($userid);
-        $this->userSession->setUser($user);
-        return new JSONResponse();
-    }
-
-
+	/**
+	 * become another user
+	 * @UseSession
+	 */
+	public function impersonate($userid) {
+		$users = $this->userManager->search($userid, 1, 0);
+		if (count($users) > 0) {
+			$user = array_shift($users);
+			if (strcasecmp($user->getUID(),$userid) === 0) {
+				$this->userSession->setUser($user);
+			}
+		}
+		return new JSONResponse();
+	}
 }
+


### PR DESCRIPTION
There is a problem with this app where if the user you enter in the impersonate field doesn't exist, it'll just send OwnCloud into an error spiral. 

The easy fix is just to wrap $this->userSession->setUser($user) in an if statement that checks that $user is not null. This results in the user being re-logged in as themselves rather than getting the error spiral.