### PR TITLE
Move location of keys to $(HOME)/.owncloud/certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,18 @@ SHELL := /bin/bash
 
 appname=$(notdir $(CURDIR))
 occ=$(CURDIR)/../../occ
-private_key=$(CURDIR)/$(appname).key
-certificate=$(CURDIR)/$(appname).crt
+private_key=$(HOME)/.owncloud/certificates/$(appname).key
+certificate=$(HOME)/.owncloud/certificates/$(appname).crt
 sign=php -f $(occ) integrity:sign-app --privateKey="$(private_key)" --certificate="$(certificate)"
+sign_skip_msg="Skipping signing, either no key and certificate found in $(private_key) and $(certificate) or occ can not be found at $(occ)"
+
+ifneq (,$(wildcard $(private_key)))
+ifneq (,$(wildcard $(certificate)))
+ifneq (,$(wildcard $(occ)))
+	CAN_SIGN=true
+endif
+endif
+endif
 
 #
 # Catch-all rules
@@ -21,7 +30,11 @@ clean: clean-build
 # build source package
 #
 build-src:
-		$(sign) --path="$(CURDIR)"
+ifdef CAN_SIGN
+	$(sign) --path="$(CURDIR)"
+else
+	@echo $(sign_skip_msg)
+endif
 		mkdir -p build
 		tar cvzf build/$(appname).tar.gz ../$(appname) \
 		--exclude-vcs \


### PR DESCRIPTION
Change the location of key and crt file to
$(HOME)/.owncloud/certificates.
Also made minor modification to the Makefile to
check if keys are available for signing.

Signed-off-by: Sujith H <sharidasan@owncloud.com>