### PR TITLE
Make logged in message permanent in users page

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -10,8 +10,10 @@
  */
 
 \OCP\App::registerAdmin('impersonate', 'settings-admin');
+
 if(\OC::$server->getSession()->get('oldUserId') !== null) {
 	\OCP\Util::addScript('impersonate','impersonate_logout');
+	\OCP\Util::addStyle('impersonate', 'impersonate');
 }
 // --- register js for user management------------------------------------------
 $eventDispatcher = \OC::$server->getEventDispatcher();

--- a/css/impersonate.css
+++ b/css/impersonate.css
@@ -1,0 +1,20 @@
+#impersonate-notification {
+	display: inline-block;
+	background-color: #fc4;
+	margin: 0 auto;
+	max-width: 60%;
+	z-index: 8000;
+	border: 0;
+	padding: 1px 8px;
+	position: relative;
+	top: 0;
+	border-bottom-left-radius: 3px;
+	border-bottom-right-radius: 3px;
+	opacity: .9;
+	margin-right: 2px;
+	vertical-align: top;
+}
+
+#notification {
+	margin-left: 2px;
+}

--- a/js/impersonate_logout.js
+++ b/js/impersonate_logout.js
@@ -2,22 +2,42 @@ $(document).ready(function () {
 
 	$("#logout").attr("href","#");
 
-	var text = t(
-		'core',
-		'<a href="{docUrl}">{displayText}</a>',
-		{
-			docUrl: OC.generateUrl('apps/files'),
-			displayText: "Logged in as " + OC.getCurrentUser().uid,
-		}
-	);
+	var TEMPLATE_BASE =
+		'<div id="impersonate-notification" ' +
+		'<div class="row">' +
+		'<a href="{{docUrl}}" style="text-align: center;">{{displayText}}</a>' +
+		'</div>' +
+		'</div>';
 
-	var timeout = 15;
-	OC.Notification.showHtml(
-		text,
-		{
-			isHTML: true, timeout
-		}
-	);
+	var ImpersonateNotification = {
+		/** @type {Object} **/
+		_templates: {},
+
+		render: function () {
+			var baseTemplate = this._getTemplate('base', TEMPLATE_BASE);
+			return baseTemplate({
+				docUrl: OC.generateUrl('apps/files'),
+				displayText: t('core','Logged in as {currentUser}', {'currentUser': OC.getCurrentUser().uid})
+			});
+		},
+
+		/**
+		 *
+		 * @param {string} key - an identifier for the template
+		 * @param {string} template - the HTML to be compiled by Handlebars
+		 * @returns {Function} from Handlebars
+		 * @private
+		 */
+		_getTemplate: function (key, template) {
+			if (!this._templates[key]) {
+				this._templates[key] = Handlebars.compile(template);
+			}
+			return this._templates[key];
+		},
+	};
+
+	var $templateImpersonate = ImpersonateNotification.render();
+	$($templateImpersonate).insertBefore("#notification");
 
 	function logoutHandler(userid) {
 		var promisObj = $.post(


### PR DESCRIPTION
Currently we are storing the data as
session. This would help to know if the
impersonation happened in the users page.
Once the user is logged out the localstorage
data is removed.

Signed-off-by: Sujith H <sharidasan@owncloud.com>