### PR TITLE
Restrict impersonate to admin user from subadmin user

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -108,6 +108,13 @@ class SettingsController extends Controller {
 				'error' => "userNeverLoggedIn",
 				'message' => "Can not impersonate",
 			], http::STATUS_NOT_FOUND);
+		} elseif ($this->groupManager->isAdmin($target) && !$this->groupManager->isAdmin($impersonator)) {
+			// If not an admin then no impersonation
+			$this->logger->warning('Can not allow user "' . $impersonator . '" trying to impersonate "'. $target . '"');
+			return new JSONResponse([
+				'error' => "cannotImpersonateAdminUser",
+				'message' => "Can not impersonate",
+			], http::STATUS_NOT_FOUND);
 		} else {
 
 			if ($this->groupManager->isAdmin($this->userSession->getUser()->getUID())) {

--- a/js/impersonate.js
+++ b/js/impersonate.js
@@ -148,6 +148,8 @@
 					OC.dialogs.alert(t('impersonate', result.responseJSON.message), t('impersonate', "Error"));
 				} else if((result.responseJSON.error === "cannotImpersonate") && (result.responseJSON.message.length > 0)){
 					OC.dialogs.alert(t('impersonate', result.responseJSON.message), t('impersonate', "Error"));
+				} else if ((result.responseJSON.error === "cannotImpersonateAdminUser") && (result.responseJSON.message.length > 0)) {
+					OC.dialogs.alert(t('impersonate', result.responseJSON.message), t('impersonate', "Error"));
 				}
 			});
 		}


### PR DESCRIPTION
Restrict the impersonation from subadmin user to admin user.
This is a case where an admin belongs to the same group
of subadmin. This change restricts the impersonation.

Signed-off-by: Sujith H <sharidasan@owncloud.com>