### PR TITLE
Move impersonate settings to user authentication section

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -9,7 +9,6 @@
  * @copyright Jörn Friedrich Dreyer 2015
  */
 
-\OCP\App::registerAdmin('impersonate', 'settings-admin');
 
 
 if(\OC::$server->getSession()->get('impersonator') !== null) {

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,25 +1,28 @@
 <?xml version="1.0"?>
 <info>
-    <id>impersonate</id>
-    <name>Impersonate</name>
-    <summary>Provide assistance by logging in as another user</summary>
-    <description>
+	<id>impersonate</id>
+	<name>Impersonate</name>
+	<summary>Provide assistance by logging in as another user</summary>
+	<description>
 The Impersonate application allows administrators to log in as another user within the ownCloud instance.
 This provides a helpdesk-like experience and can for example be useful to help users with configuration issues, to get a better understanding of what they see when they use their ownCloud account or to conduct actions in legacy accounts. 
 Once Impersonate is installed a new column will be available in the user management panel. Simply click on the icon next to the user that you want to impersonate and you will be logged in as that user. Your current session will be temporarily suspended and you will see a notification at the top of the page that confirms and reminds that you’re impersonating another user. Once you’re done, log out and you will return to your previous user session.
 As a security measure, the application lets ownCloud administrators restrict the ability to impersonate users in certain groups. When enabled and configured, only a group’s administrator can impersonate members of their group.
 Administrators can find configuration options in the 'User Authentication" section of the admin settings panel.</description>
-    <licence>AGPL</licence>
-    <author>Jörn Friedrich Dreyer</author>
-    <version>0.1.0</version>
-    <documentation>
+	<licence>AGPL</licence>
+	<author>Jörn Friedrich Dreyer</author>
+	<version>0.1.0</version>
+	<documentation>
 	<admin>https://doc.owncloud.org/server/latest/admin_manual/issues/impersonate_users.html</admin>
-    </documentation>
-    <bugs>https://github.com/owncloud/impersonate/issues</bugs>
-    <repository type="git">http://github.com/owncloud/impersonate.git</repository>
-    <dependencies>
-        <owncloud min-version="10.0.4" max-version="10.0" />
-    </dependencies>
-    <category>tools</category>
-    <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/impersonate/impersonate.png</screenshot>
+	</documentation>
+	<bugs>https://github.com/owncloud/impersonate/issues</bugs>
+	<repository type="git">http://github.com/owncloud/impersonate.git</repository>
+	<dependencies>
+		<owncloud min-version="10.0.4" max-version="10.0" />
+	</dependencies>
+	<category>tools</category>
+	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/impersonate/impersonate.png</screenshot>
+	<settings>
+		<admin>OCA\Impersonate\AdminPanel</admin>
+	</settings>
 </info>

--- a/lib/AdminPanel.php
+++ b/lib/AdminPanel.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Impersonate;
+
+use OCP\Settings\ISettings;
+use OCP\Template;
+
+class AdminPanel implements ISettings {
+
+
+	public function getPanel() {
+		$t = new Template('impersonate', 'settings-admin');
+		return $t;
+	}
+
+	public function getSectionID() {
+		return 'authentication';
+	}
+
+	public function getPriority() {
+		return 0;
+	}
+}

--- a/settings-admin.php
+++ b/settings-admin.php
@@ -1,9 +1,0 @@
-<?php
-
-\OC_Util::checkAdminUser();
-
-\OCP\Util::addStyle('impersonate', 'settings-admin');
-\OCP\Util::addScript('impersonate', 'settings-admin');
-
-$tmpl = new OCP\Template( 'impersonate', 'settings-admin' );
-return $tmpl->fetchPage();

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -1,3 +1,7 @@
+<?php
+script('impersonate', 'settings-admin');
+style('impersonate', 'settings-admin');
+?>
 <div class="section" id="impersonateTemplateSettings" >
 
 	<h2><?php p($l->t('Impersonate Settings'));?></h2>


### PR DESCRIPTION
Move the impersonate settings to
User Authentication section in the
admin settings.

Signed-off-by: Sujith H <sharidasan@owncloud.com>