### PR TITLE
Add dist to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ endif
 #
 # Catch-all rules
 #
-.PHONY: all
-all: build-src
+.PHONY: dist
+dist: build-src
 
 .PHONY: clean
 clean: clean-build
@@ -43,10 +43,10 @@ ifdef CAN_SIGN
 		build/$(appname)
 	cp settings-admin.php build/$(appname)
 	$(sign) --path="$(CURDIR)/build/$(appname)"
+	tar -czf build/$(appname).tar.gz -C $(CURDIR)/build/$(appname) ../$(appname)
 else
 	@echo $(sign_skip_msg)
 endif
-	tar -czf build/$(appname).tar.gz -C $(CURDIR)/build/$(appname) ../$(appname)
 
 .PHONY: clean
 clean-build:


### PR DESCRIPTION
Replace all with dist. Now user
can execute $make dist
to build the app.

Signed-off-by: Sujith H <sharidasan@owncloud.com>