### PR TITLE
Removing logout logic from the js

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -11,6 +11,7 @@
 
 \OCP\App::registerAdmin('impersonate', 'settings-admin');
 
+
 if(\OC::$server->getSession()->get('impersonator') !== null) {
 	\OCP\Util::addScript('impersonate','impersonate_logout');
 	\OCP\Util::addStyle('impersonate', 'impersonate');
@@ -23,4 +24,14 @@ $eventDispatcher->addListener(
 		\OCP\Util::addScript('impersonate', 'impersonate');
 	}
 );
+$logoutController = new OCA\Impersonate\Controller\LogoutController(
+	'impersonate',
+	\OC::$server->getRequest(),
+	\OC::$server->getUserManager(),
+	OC::$server->getUserSession(),
+	OC::$server->getLogger(),
+	OC::$server->getSession()
+);
+$eventDispatcher->addListener('\OC\User\Session::pre_logout', [$logoutController, 'logoutcontroller']);
+
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ Administrators can find configuration options in the 'User Authentication" secti
     <bugs>https://github.com/owncloud/impersonate/issues</bugs>
     <repository type="git">http://github.com/owncloud/impersonate.git</repository>
     <dependencies>
-        <owncloud min-version="9.0" max-version="10.0" />
+        <owncloud min-version="10.0.4" max-version="10.0" />
     </dependencies>
     <category>tools</category>
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/impersonate/impersonate.png</screenshot>

--- a/js/impersonate_logout.js
+++ b/js/impersonate_logout.js
@@ -1,7 +1,5 @@
 $(document).ready(function () {
 
-	$("#logout").attr("href","#");
-
 	var TEMPLATE_BASE =
 		'<div id="impersonate-notification" ' +
 		'<div class="row">' +
@@ -39,22 +37,4 @@ $(document).ready(function () {
 	var $templateImpersonate = ImpersonateNotification.render();
 	$($templateImpersonate).insertBefore("#notification");
 
-	function logoutHandler() {
-		var promisObj = $.post(
-			OC.generateUrl('apps/impersonate/logout')
-		).promise();
-
-		promisObj.done(function () {
-			OC.redirect('apps/files');
-		}).fail(function (result) {
-			if ((result.responseJSON.error === "cannotLogout") && (result.responseJSON.message.length > 0))
-			OC.dialogs.alert(t('impersonate', result.responseJSON.message),t('impersonate', "Error"));
-		});
-
-	}
-
-		$("#logout").on('click', function (event) {
-			event.preventDefault();
-			logoutHandler();
-		});
 });

--- a/tests/controller/logoutcontrollertest.php
+++ b/tests/controller/logoutcontrollertest.php
@@ -21,6 +21,7 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OC\Group\Backend;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
 
 /**
@@ -44,6 +45,7 @@ class LogoutControllerTest extends TestCase {
 	private $logger;
 	/** @var ISession  */
 	private $session;
+	private $eventDispatcher;
 
 	public function setUp() {
 		$this->appName = 'impersonate';
@@ -73,8 +75,7 @@ class LogoutControllerTest extends TestCase {
 			$this->userManager,
 			$this->userSession,
 			$this->logger,
-			$this->session
-		);
+			$this->session);
 
 		parent::setUp();
 	}
@@ -91,7 +92,7 @@ class LogoutControllerTest extends TestCase {
 	 * @param $userId
 	 */
 	public function  testImpersonateLogout($userId) {
-
+		$genericEvent = new GenericEvent(null, ['cancel' => false]);
 		if($userId === null) {
 			$this->session->expects($this->once())
 				->method('get')
@@ -102,7 +103,7 @@ class LogoutControllerTest extends TestCase {
 					'error' => "cannotLogout",
 					'message' => "Cannot logout"
 				], Http::STATUS_NOT_FOUND),
-				$this->controller->logoutcontroller()
+				$this->controller->logoutcontroller($genericEvent)
 			);
 		} else {
 			$this->session->expects($this->once())
@@ -115,9 +116,10 @@ class LogoutControllerTest extends TestCase {
 
 			$this->assertEquals(
 				new JSONResponse(),
-				$this->controller->logoutcontroller()
+				$this->controller->logoutcontroller($genericEvent)
 			);
 		}
 	}
+
 }
 


### PR DESCRIPTION
This change is to remove logout logic
of impersonate app from the javascript
to php. Now onwards we rely on prelogout
hooks.

Signed-off-by: Sujith H <sharidasan@owncloud.com>