### PR TITLE
Removing the extra '+' character from handlebar

### DIFF
--- a/js/templates/addImpersonateIcon.handlebars
+++ b/js/templates/addImpersonateIcon.handlebars
@@ -1,4 +1,4 @@
-+<td>
+<td>
 	<a class="action permanent impersonate" href="#" title="{{impersonate}}">
 		<img class="svg permanent action" src="{{impersonate_src}}" />
 	</a>


### PR DESCRIPTION
Removing the extra '+' character from the handlebar
file so that impersonate icon could be visible for
the users.

Signed-off-by: Sujith H <sharidasan@owncloud.com>