### PR TITLE
More defensive group checking for Impersonation

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -178,7 +178,7 @@ class SettingsController extends Controller {
 				$includedGroups = json_decode($includedGroups);
 
 				foreach ($includedGroups as $group) {
-					if($this->groupManager->get($group)->inGroup($user)
+					if($this->groupManager->isInGroup($user->getUID(), $group)
 						&& $this->subAdmin->isSubAdminofGroup($this->userSession->getUser(), $this->groupManager->get($group))) {
 						$this->logger->info("User $impersonator impersonated user $target", ['app' => 'impersonate']);
 						$this->util->switchUser($user, $impersonator);

--- a/tests/controller/SettingsControllerTest.php
+++ b/tests/controller/SettingsControllerTest.php
@@ -179,13 +179,14 @@ class SettingsControllerTest extends TestCase {
 				->willReturn(json_encode([$group]));
 
 			$iGroup = $this->createMock(IGroup::class);
-			$iGroup->expects($this->any())
-				->method('inGroup')
-				->willReturn(true);
 
 			$this->groupManger->expects($this->any())
 				->method('get')
 				->willReturn($iGroup);
+
+			$this->groupManger->expects($this->any())
+				->method('isInGroup')
+				->willReturn(true);
 
 
 			$this->subAdmin->expects($this->any())
@@ -260,13 +261,14 @@ class SettingsControllerTest extends TestCase {
 			->willReturn(json_encode(['testgroup']));
 
 		$iGroup = $this->createMock(IGroup::class);
-		$iGroup->expects($this->any())
-			->method('inGroup')
-			->willReturn(true);
 
 		$this->groupManger->expects($this->any())
 			->method('get')
 			->willReturn($iGroup);
+
+		$this->groupManger->expects($this->any())
+			->method('isInGroup')
+			->willReturn(true);
 
 
 		$this->subAdmin->expects($this->any())
@@ -311,9 +313,6 @@ class SettingsControllerTest extends TestCase {
 			->willReturn(json_encode(['testgroup','testgroup2']));
 
 		$iGroup = $this->createMock(IGroup::class);
-		$iGroup->expects($this->any())
-			->method('inGroup')
-			->willReturn(true);
 
 		$this->groupManger->expects($this->any())
 			->method('get')
@@ -325,6 +324,15 @@ class SettingsControllerTest extends TestCase {
 				)
 			);
 
+		$this->groupManger->expects($this->any())
+			->method('isInGroup')
+			->will(
+				$this->returnValueMap([
+						['username','testgroup', false],
+						['username','testgroup2', true]
+					]
+				)
+			);
 
 		$this->subAdmin->expects($this->any())
 			->method('isSubAdminofGroup')


### PR DESCRIPTION
The scenario uncovered in https://github.com/owncloud/impersonate/issues/118 highlighted, that a vanishing group ( either by removal or rename ) would fail impersonation, as the methods used would try to exercise a method call on a missing object.

This refactoring uses the already available `isInGroup` method of the `groupManager` to avoid this scenario

@sharidas 
Maybe you can provide more insight why `$this->groupManager->get($group)->inGroup($user)` instead of `$this->groupManager->isInGroup($userid, $group);` was used at https://github.com/owncloud/impersonate/blob/master/controller/settingscontroller.php#L181

## Testing
- [x] unit test to confirm behavior
- [ ] manual test

Needs further manual testing to confirm everything continues to work as expected