### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ As a security measure, the application lets ownCloud administrators restrict the
 	<bugs>https://github.com/owncloud/impersonate/issues</bugs>
 	<repository type="git">http://github.com/owncloud/impersonate.git</repository>
 	<dependencies>
-		<owncloud min-version="10.0.4" max-version="10" />
+		<owncloud min-version="10.2" max-version="10" />
 	</dependencies>
 	<category>tools</category>
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/impersonate/impersonate.png</screenshot>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "owncloud/impersonate",
     "config": {
         "platform": {
-            "php": "5.6.37"
+            "php": "7.0.8"
         }
     },
     "require": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "06575ca02c07c9e9f2952b7df7fe27ab",
+    "content-hash": "745cf3efcbb9553c0e8ce8b91b2afc18",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
