### PR TITLE
[tests-only] [full-ci] Remove npm checks from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ js_namespace=OCA.$(app_namespace)
 NODE_PREFIX=$(shell pwd)
 
 NPM := $(shell command -v npm 2> /dev/null)
-ifndef NPM
-	$(error npm is not available on your system, please install npm)
-endif
 
 ifneq (,$(wildcard $(private_key)))
 ifneq (,$(wildcard $(certificate)))


### PR DESCRIPTION
The `owncloudci/php` image no longer has nodejs, npm or yarn. It runs PHP tests fine, and we should not complain that `npm` is missing.

Remove the annoying checks from `Makefile`