### PR TITLE
Fix encryption issues after the impersonator logs out

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,6 +13,7 @@ As a security measure, the application lets ownCloud administrators restrict the
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Sujith Haridasan</author>
 	<version>0.5.0</version>
+	<namespace>Impersonate</namespace>
 	<documentation>
 	<admin>https://doc.owncloud.org/server/latest/admin_manual/issues/impersonate_users.html</admin>
 	</documentation>

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * @author Sujith Haridasan <sharidasan@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2021, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -58,7 +59,10 @@ class Util {
 	}
 
 	/**
-	 * Switch from admin/subAdmin $impersonator to $user
+	 * Switch from admin/subAdmin $impersonator to $user (and vice versa).
+	 * $impersonator is empty in case the impersonator switches back to their profile.
+	 * The impersonator must be given via the $user attribute then.
+	 *
 	 * @param IUser $user
 	 * @param mixed $impersonator
 	 */
@@ -66,15 +70,42 @@ class Util {
 		$this->tokenProvider->invalidateToken($this->session->getId());
 		$this->userSession->setUser($user);
 		$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
-		//Store the session var impersonator with the impersonator value
-		if (($this->session->get('impersonator') === null) &&
-			($impersonator !== null)) {
-			$this->session->set('impersonator', $impersonator);
+
+		if ($impersonator !== null) {
+			// Store the session var impersonator with the impersonator value
+			if ($this->session->get('impersonator') === null) {
+				$this->session->set('impersonator', $impersonator);
+			}
+
+			// Save the impersonator's encryption key in another session variable to reset it again later.
+			// This is neccessary because the "privateKey" var gets removed on logout.
+			$encryptionInitialized = $this->session->get('encryptionInitialized');
+			if ($encryptionInitialized  !== null) {
+				$this->session->set('impersonatorEncryptionInitialized', $encryptionInitialized);
+			}
+
+			$privateKey = $this->session->get('privateKey');
+			if ($privateKey !== null) {
+				$this->session->set('impersonatorPrivateKey', $privateKey);
+			}
 		}
 
-		//Remove the session variable impersonator set as it is a logout
 		if (($impersonator === '') || ($impersonator === null)) {
+			// Remove the session variable impersonator set as it is a logout
 			$this->session->remove('impersonator');
+
+			// Reset encryption key for the impersonator.
+			$impersonatorEncryptionInitialized = $this->session->get('impersonatorEncryptionInitialized');
+			if ($impersonatorEncryptionInitialized !== null) {
+				$this->session->set('encryptionInitialized', $impersonatorEncryptionInitialized);
+				$this->session->remove('impersonatorEncryptionInitialized');
+			}
+
+			$impersonatorPrivateKey = $this->session->get('impersonatorPrivateKey');
+			if ($impersonatorPrivateKey !== null) {
+				$this->session->set('privateKey', $impersonatorPrivateKey);
+				$this->session->remove('impersonatorPrivateKey');
+			}
 		}
 	}
 }

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -80,7 +80,7 @@ class Util {
 			// Save the impersonator's encryption key in another session variable to reset it again later.
 			// This is neccessary because the "privateKey" var gets removed on logout.
 			$encryptionInitialized = $this->session->get('encryptionInitialized');
-			if ($encryptionInitialized  !== null) {
+			if ($encryptionInitialized !== null) {
 				$this->session->set('impersonatorEncryptionInitialized', $encryptionInitialized);
 			}
 
@@ -88,9 +88,7 @@ class Util {
 			if ($privateKey !== null) {
 				$this->session->set('impersonatorPrivateKey', $privateKey);
 			}
-		}
-
-		if (($impersonator === '') || ($impersonator === null)) {
+		} else {
 			// Remove the session variable impersonator set as it is a logout
 			$this->session->remove('impersonator');
 


### PR DESCRIPTION
We now save the private key in another session variable to preserve and reset it after an impersonator logs out to use their original user again.

I also refactored some unit tests and added a namespace in the `info.xml` file. 

## Steps to reproduce:

* Enable encryption
* Impersonate another user
* Logout to switch back to your user again -> there shouldn't be any issues with encryption whatsoever.

fixes https://github.com/owncloud/enterprise/issues/4887