### PR TITLE
restrict impersonation to users allowed to use the app

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -202,11 +202,6 @@ class SettingsController extends Controller {
 				'message' => $this->l->t('Can not impersonate'),
 			], http::STATUS_NOT_FOUND);
 		} else {
-			// admin is unconditionally allowed to impersonate
-			if ($this->groupManager->isAdmin($currentUser->getUID())) {
-				return $this->impersonateUser($impersonator, $target, $user);
-			}
-
 			// check if feature "enable app for certain groups" is used, and if yes, do validation
 			if ($appEnabled !== "yes") {
 				// when config->getValue('impersonate', 'enabled') is not 'yes' or 'no'
@@ -238,6 +233,11 @@ class SettingsController extends Controller {
 				}
 			}
 
+			// admin is unconditionally allowed to impersonate
+			if ($this->groupManager->isAdmin($currentUser->getUID())) {
+				return $this->impersonateUser($impersonator, $target, $user);
+			}
+			
 			$includedGroups = $this->config->getValue('impersonate', 'impersonate_include_groups_list', '');
 			$allowSubAdminsImpersonate = $this->config->getValue('impersonate', 'impersonate_all_groupadmins', "false");
 			if ($allowSubAdminsImpersonate === "true") {

--- a/tests/unit/controller/SettingsControllerTest.php
+++ b/tests/unit/controller/SettingsControllerTest.php
@@ -171,6 +171,11 @@ class SettingsControllerTest extends TestCase {
 			->willReturn(1);
 
 		if ($group === 'admin') {
+			$this->config
+				->method('getValue')
+				->will($this->returnValueMap([
+					['impersonate', 'enabled', "no", "yes"]
+				]));
 			//This user belongs to admin user
 			$this->groupManger->expects($this->any())
 				->method('isAdmin')


### PR DESCRIPTION
fixes https://github.com/owncloud/enterprise/issues/5167

- [x] manual testing
- [x] unit and integration tests

How tested?

1. Init
```
occ a:e impersonate

occ config:app:set impersonate enabled --value '["admin"]'
occ config:app:set impersonate impersonate_all_groupadmins --value true

export OC_PASS=test
occ user:add --email test1@test.com --password-from-env test1

occ group:add grp1
occ group:add-member grp1 --member test1
```

2. Log in as test1, and then as admin
3. Try to impersonate test1, it should show message `Cannot impersonate...`

Show proper message when trying to impersonate from or to user for which app is not enabled 
![Screenshot 2022-06-01 at 08 20 19](https://user-images.githubusercontent.com/13368647/171340513-43be7e16-fbf4-4b3f-9019-853710603b64.png)
![Screenshot 2022-06-01 at 00 18 35](https://user-images.githubusercontent.com/13368647/171339800-ced9cb23-a5c8-4f69-b98f-3158706ccf34.png)
