### PR TITLE
Fix impersonate include groups list

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -183,7 +183,7 @@ class SettingsController extends Controller {
 			$this->session->remove('impersonator');
 			return new JSONResponse([
 				'error' => 'userNotFound',
-				'message' => $this->l->t('Unexpected error occured'),
+				'message' => $this->l->t('Unexpected error occurred'),
 			], Http::STATUS_NOT_FOUND);
 		} elseif ($user->getLastLogin() === 0) {
 			// It's a first time login
@@ -213,12 +213,12 @@ class SettingsController extends Controller {
 					$this->session->remove('impersonator');
 					return new JSONResponse([
 						'error' => 'cannotImpersonate',
-						'message' => $this->l->t('Unexpected error occured.')
+						'message' => $this->l->t('Unexpected error occurred.')
 					], http::STATUS_NOT_FOUND);
 				}
 				foreach ($appEnabledGroupIds as $appEnabledGroupId) {
 					// validate here whether target user is allowed to use the app, otherwise app javascript and other related
-					// code will not be rechable for that user when impersonation happens
+					// code will not be reachable for that user when impersonation happens
 					// NOTE: we do not need to check impersonator as this code path is already not reachable for that user
 					if (!$this->groupManager->isInGroup($target, $appEnabledGroupId)) {
 						$this->logger->warning(

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -78,7 +78,7 @@ class Util {
 			}
 
 			// Save the impersonator's encryption key in another session variable to reset it again later.
-			// This is neccessary because the "privateKey" var gets removed on logout.
+			// This is necessary because the "privateKey" var gets removed on logout.
 			$encryptionInitialized = $this->session->get('encryptionInitialized');
 			if ($encryptionInitialized !== null) {
 				$this->session->set('impersonatorEncryptionInitialized', $encryptionInitialized);

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -26,7 +26,7 @@ style('impersonate', 'settings-admin');
 	p('hidden');
 } ?>">
 		<input name="impersonate_include_groups_list" type="hidden" id="includedGroups" value="<?php
-		$includeGroupList = \OC::$server->getAppConfig()->getValue('impersonate', 'impersonate_include_groups_list', []);
+		$includeGroupList = \OC::$server->getAppConfig()->getValue('impersonate', 'impersonate_include_groups_list', "[]");
 		$includeGroupList = \json_decode($includeGroupList);
 		$listToPrint = \count($includeGroupList) > 0 ? \implode('|', $includeGroupList) : '';
 		p($listToPrint);

--- a/tests/unit/controller/SettingsControllerTest.php
+++ b/tests/unit/controller/SettingsControllerTest.php
@@ -133,7 +133,7 @@ class SettingsControllerTest extends TestCase {
 		$this->assertEquals(
 			new JSONResponse([
 				'error' => 'userNotFound',
-				'message' => $this->l->t("Unexpected error occured")
+				'message' => $this->l->t("Unexpected error occurred")
 			], Http::STATUS_NOT_FOUND),
 			$this->controller->impersonate('notexisting@uid')
 		);
@@ -666,7 +666,7 @@ class SettingsControllerTest extends TestCase {
 
 		$this->assertEquals(
 			new JSONResponse(['error' => "cannotImpersonate",
-				'message' => $this->l->t("Unexpected error occured.")
+				'message' => $this->l->t("Unexpected error occurred.")
 			], http::STATUS_NOT_FOUND),
 			$this->controller->impersonate($query)
 		);


### PR DESCRIPTION
When I browse to Admin Settings, User Authentication, and I have not set up any `impersonate_include_groups_list` then I get this in the log:
```
$ cat data/owncloud.log 
{"reqId":"G3Pg6wgLIr7dgWUF8Bgs","level":3,"time":"2022-09-15T09:11:11+00:00","remoteAddr":"192.168.1.65","user":"admin","app":"PHP","method":"GET","url":"\/index.php\/settings\/admin?sectionid=authentication","message":"json_decode() expects parameter 1 to be string, array given at \/home\/phil\/git\/owncloud\/core\/apps-external\/impersonate\/templates\/settings-admin.php#30"}
{"reqId":"G3Pg6wgLIr7dgWUF8Bgs","level":3,"time":"2022-09-15T09:11:11+00:00","remoteAddr":"192.168.1.65","user":"admin","app":"PHP","method":"GET","url":"\/index.php\/settings\/admin?sectionid=authentication","message":"count(): Parameter must be an array or an object that implements Countable at \/home\/phil\/git\/owncloud\/core\/apps-external\/impersonate\/templates\/settings-admin.php#31"}
```

The default empty array needs to be provided as the string "[]" and not as an actual `[]` empty array.

I also fixed some typos.