### PR TITLE
Bump handlebars from 4.5.3 to 4.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,22 @@
  "requires": true,
  "dependencies": {
   "handlebars": {
-   "version": "4.5.3",
-   "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-   "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+   "version": "4.7.7",
+   "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+   "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
    "dev": true,
    "requires": {
+    "minimist": "^1.2.5",
     "neo-async": "^2.6.0",
-    "optimist": "^0.6.1",
     "source-map": "^0.6.1",
-    "uglify-js": "^3.1.4"
+    "uglify-js": "^3.1.4",
+    "wordwrap": "^1.0.0"
    }
   },
   "minimist": {
-   "version": "0.0.10",
-   "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-   "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+   "version": "1.2.5",
+   "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+   "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
    "dev": true
   },
   "neo-async": {
@@ -28,16 +29,6 @@
    "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
    "dev": true
   },
-  "optimist": {
-   "version": "0.6.1",
-   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-   "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-   "dev": true,
-   "requires": {
-    "minimist": "~0.0.1",
-    "wordwrap": "~0.0.2"
-   }
-  },
   "source-map": {
    "version": "0.6.1",
    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -45,16 +36,16 @@
    "dev": true
   },
   "uglify-js": {
-   "version": "3.12.1",
-   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
-   "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==",
+   "version": "3.14.5",
+   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.5.tgz",
+   "integrity": "sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==",
    "dev": true,
    "optional": true
   },
   "wordwrap": {
-   "version": "0.0.3",
-   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-   "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+   "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
    "dev": true
   }
  }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
  "contributors": [],
  "dependencies": {},
  "devDependencies": {
-  "handlebars": "^4.5.3"
+  "handlebars": "^4.7.7"
  },
  "engine": "node >= 6.9",
  "scripts": {


### PR DESCRIPTION
cherry-pick handlebars 4.7.7 bump from PR #194 into `release-0.5.2`

That makes it match the version that core is currently using, which should be safe.