### PR TITLE
fix: group admins can impersonate again

### DIFF
--- a/js/impersonate.js
+++ b/js/impersonate.js
@@ -53,6 +53,14 @@
 					$tr.find('.impersonateDisabled').remove();
 
 					var groupsSelectedByUser = $tr.find('.groups').data('groups');
+					if (!_.isArray(groupsSelectedByUser)) {
+						// We need the gid.
+						// For older OC versions (10.13-), the "groupsSelectedByUser"
+						// is an array containing groups. For newer OC versions (10.13+)
+						// it maps each gid with additional data such as displayname, so
+						// we need to extract the keys of the map
+						groupsSelectedByUser = _.keys(groupsSelectedByUser);
+					}
 
 					if ($tr.data('uid') === $.trim(currentUser)) {
 						removeImpersonateIcon($tr);


### PR DESCRIPTION
Rel: https://github.com/owncloud/enterprise/issues/6277

There have been some changes in core (around 10.13) to keep a different data structure for the group information in order to make it more flexible. Due to this change, some of the impersonation functionality wasn't working.

This PR fixes the problem and keeps backwards compatibility, so the app can keep the minimum OC version.