### PR TITLE
fix:enable only for specific groups

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -235,6 +235,7 @@ class SettingsController extends Controller {
 						'message' => $this->l->t('Can not impersonate. Please contact your server administrator to allow impersonation.')
 					], http::STATUS_NOT_FOUND);
 				}
+                                return $this->impersonateUser($impersonator, $target, $user);
 			}
 
 			// admin is unconditionally allowed to impersonate


### PR DESCRIPTION
When only selecting the app setting `Enable only for specific groups`, impersonation fails with an `Can not impersonate` error. Currently, the logic to impersonate the user is missing when only this app setting is set. This PR just add a call to the `impersonateUser()` method once all conditions are verified.