### PR TITLE
feature:remove enable only for specific groups

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@ As a security measure, the application lets ownCloud administrators restrict the
 </description>
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Sujith Haridasan</author>
-	<version>0.5.4</version>
+	<version>0.5.2</version>
         <types>
 	       <authentication/>
         </types>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,10 @@ As a security measure, the application lets ownCloud administrators restrict the
 </description>
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Sujith Haridasan</author>
-	<version>0.5.2</version>
+	<version>0.5.4</version>
+        <types>
+	       <authentication/>
+        </types>
 	<namespace>Impersonate</namespace>
 	<documentation>
 	<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/general_topics/impersonate_users.html</admin>

--- a/tests/unit/controller/SettingsControllerTest.php
+++ b/tests/unit/controller/SettingsControllerTest.php
@@ -628,49 +628,6 @@ class SettingsControllerTest extends TestCase {
 		);
 	}
 
-	public function testImpersonateAppEnableInvalidConfig() {
-		$query='NormalUser';
-		$uid='username';
-
-		$this->config
-			->method('getValue')
-			->will($this->returnValueMap([
-				['impersonate', 'enabled', "no", "invalid value"],
-			]));
-		
-		$user = $this->createMock('\OCP\IUser');
-
-		$user->method('getUID')
-			->willReturn($uid);
-
-		$user->expects($this->once())
-			->method('getLastLogin')
-			->willReturn(1);
-
-		$this->userSession
-			->method('getUser')
-			->willReturn($user);
-	
-		$this->userManager->expects($this->atLeastOnce())
-			->method('get')
-			->with($query)
-			->willReturn($user);
-	
-		$this->groupManger->expects($this->any())
-			->method('isAdmin')
-			->willReturn(false);
-
-		$this->session->expects($this->once())
-			->method('remove');
-
-		$this->assertEquals(
-			new JSONResponse(['error' => "cannotImpersonate",
-				'message' => $this->l->t("Unexpected error occurred.")
-			], http::STATUS_NOT_FOUND),
-			$this->controller->impersonate($query)
-		);
-	}
-
 	public function testImpersonateAppEnabledForTargetUser() {
 		$query='NormalUser';
 		$uid='username';
@@ -716,53 +673,6 @@ class SettingsControllerTest extends TestCase {
 
 		$this->assertEquals(
 			new JSONResponse(),
-			$this->controller->impersonate($query)
-		);
-	}
-
-	public function testImpersonateAppNotEnabledForTargetUser() {
-		$query='NormalUser';
-		$uid='username';
-
-		$this->config
-			->method('getValue')
-			->will($this->returnValueMap([
-				['impersonate', 'enabled', "no", \json_encode(["app_enabled_group"])],
-			]));
-		
-		$user = $this->createMock('\OCP\IUser');
-
-		$user->method('getUID')
-			->willReturn($uid);
-
-		$user->expects($this->once())
-			->method('getLastLogin')
-			->willReturn(1);
-
-		$this->userSession
-			->method('getUser')
-			->willReturn($user);
-	
-		$this->userManager->expects($this->atLeastOnce())
-			->method('get')
-			->with($query)
-			->willReturn($user);
-	
-		$this->groupManger->expects($this->any())
-			->method('isAdmin')
-			->willReturn(false);
-
-		$this->groupManger->expects($this->any())
-			->method('isInGroup')
-			->willReturn(false);
-
-		$this->session->expects($this->once())
-			->method('remove');
-
-		$this->assertEquals(
-			new JSONResponse(['error' => "cannotImpersonate",
-				'message' => $this->l->t("Can not impersonate. Please contact your server administrator to allow impersonation.")
-			], http::STATUS_NOT_FOUND),
 			$this->controller->impersonate($query)
 		);
 	}


### PR DESCRIPTION
As discussed at https://github.com/owncloud/impersonate/pull/237, it makes sense to remove the `Enable only for specific groups` app setting as the `Impersonate Settings` section on the `User authentication` page already gives admin the possibility to select different options for groups admin management.