### PR TITLE
chore(ci): run acceptance tests in GitHub workflows

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,241 @@
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: 'Name of the app'
+        required: true
+        type: string
+      php-versions:
+        description: JSON array of PHP versions
+        required: false
+        type: string
+        default: '["8.3"]'
+      databases:
+        description: JSON array of databases
+        required: false
+        type: string
+        default: '["mariadb:10.6"]'
+      app-repository:
+        description: 'Repository of the app (optional, defaults to the current repository)'
+        required: false
+        type: string
+        default: ''
+      do-api-tests:
+        description: 'Whether to run API acceptance tests'
+        required: false
+        type: boolean
+        default: false
+      do-cli-tests:
+        description: 'Whether to run CLI acceptance tests'
+        required: false
+        type: boolean
+        default: false
+      do-webui-tests:
+        description: 'Whether to run WebUI acceptance tests'
+        required: false
+        type: boolean
+        default: false
+      additional-app:
+        description: 'Additional app to enable for testing'
+        required: false
+        type: string
+        default: ''
+      additional-app-github-token:
+        description: 'GitHub PAT to access the additional app repo - required if private'
+        required: false
+        type: string
+        default: ''
+      additional-packages:
+        description: Additional Linux packages to be installed - space separated
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  acceptance:
+    name: Acceptance tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ${{ fromJSON(inputs.php-versions) }}
+        database: ${{ fromJSON(inputs.databases) }}
+
+    services:
+      mysql:
+        image: >-
+          ${{ (startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:')) && matrix.database || '' }}
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: owncloud
+          MYSQL_USER: owncloud
+          MYSQL_PASSWORD: owncloud
+        options: >-
+          --health-cmd="mysqladmin ping -u root -ppassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+        ports:
+          - 3306:3306
+      postgres:
+        image: ${{ startsWith(matrix.database,'postgres:') && matrix.database || '' }}
+        env:
+          POSTGRES_DB: owncloud
+          POSTGRES_USER: owncloud
+          POSTGRES_PASSWORD: owncloud
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Clone owncloud/core
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: owncloud/core
+
+      - name: Checkout apps/${{ inputs.app-name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: apps/${{ inputs.app-name }}
+          repository: ${{ inputs.app-repository }}
+
+      - name: Checkout apps/${{ inputs.additional-app }}
+        if: ${{ inputs.additional-app != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: apps/${{ inputs.additional-app }}
+          repository: owncloud/${{ inputs.additional-app }}
+          token: ${{ inputs.additional-app-github-token || github.token }}
+
+      - name: Install Linux packages
+        if: ${{ inputs.additional-packages }}
+        run: |
+          sudo apt-get install ${{ inputs.additional-packages }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: apcu, ctype, curl, exif, fileinfo, gd, iconv, imagick, intl, json, mbstring, memcached, pdo, posix, simplexml, xml, zip, smbclient, ldap, krb5
+          ini-values: "memory_limit=1024M"
+        env:
+          fail-fast: true
+          KRB5_LINUX_LIBS: libkrb5-dev
+
+      - name: Install Apache
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libapache2-mod-php${{ matrix.php }}
+          sudo apt-get install -y apache2
+          sudo a2enmod rewrite
+          sudo service apache2 restart
+
+      - name: Check Apache server status
+        run: curl http://localhost:80
+
+      - name: Install owncloud/core
+        run: |
+          docker run -v /var/www/html:/var/www/html \
+            --network=host \
+            -e PLUGIN_VERSION=${VERSION} \
+            -e PLUGIN_CORE_PATH=${CORE_PATH} \
+            -e PLUGIN_DB_TYPE=${DB_TYPE} \
+            -e PLUGIN_DB_NAME=${DB_NAME} \
+            -e PLUGIN_DB_HOST=${DB_HOST} \
+            -e PLUGIN_DB_USERNAME=${DB_USERNAME} \
+            -e PLUGIN_DB_PASSWORD=${DB_PASSWORD} \
+            owncloudci/core:php83
+        env:
+          VERSION: 'daily-master-qa'
+          CORE_PATH: '/var/www/html/server'
+          DB_TYPE: 'mysql'
+          DB_NAME: 'owncloud'
+          DB_HOST: '127.0.0.1'
+          DB_USERNAME: 'owncloud'
+          DB_PASSWORD: 'owncloud'
+
+      - name: Setup permissions for the backend of the Apache server
+        run: |
+          sudo chown -R www-data:www-data /var/www/html/server
+          sudo chmod -R 777 /var/www/html/server
+
+      - name: Selenium
+        if: ${{ inputs.do-webui-tests }}
+        run: |
+          docker run -d --rm --network host \
+            --name selenium-chrome \
+            selenium/standalone-chrome-debug:3.141.59-oxygen
+
+      - name: Make local core
+        run: |
+          make
+
+      - name: Setup app ${{ inputs.app-name }}
+        run: |
+          cd apps/${{ inputs.app-name }}
+          make ci
+          sudo -u www-data mkdir /var/www/html/server/apps/${{ inputs.app-name }}
+          sudo -u www-data cp -r * /var/www/html/server/apps/${{ inputs.app-name }}
+          cd /var/www/html/server
+          sudo -u www-data php occ a:e ${{ inputs.app-name }}
+
+      - name: Setup additional app ${{ inputs.app-name }}
+        if: ${{ inputs.additional-app != '' }}
+        run: |
+          cd apps/${{ inputs.additional-app }}
+          make ci
+          sudo -u www-data mkdir /var/www/html/server/apps/${{ inputs.additional-app }}
+          sudo -u www-data cp -r * /var/www/html/server/apps/${{ inputs.additional-app }}
+          cd /var/www/html/server
+          sudo -u www-data php occ a:e ${{ inputs.additional-app }}
+
+      - name: Setup owncloud server settings
+        run: |
+          cd /var/www/html/server
+          sudo -u www-data php occ config:system:set trusted_domains 1 --value=localhost
+          sudo -u www-data php occ log:manage --level 2
+          sudo -u www-data php occ config:system:set csrf.disabled --value=true
+          sudo -u www-data php occ a:e testing
+          sudo -u www-data php occ a:l -e
+
+      - name: Check access to status
+        run: curl http://localhost:80/server/status.php
+
+      - name: Install libxml2-utils to get xmllint used by acceptance test script
+        run: sudo apt install -y libxml2-utils
+
+      - name: Run API acceptance tests
+        if: ${{ inputs.do-api-tests }}
+        env:
+          TEST_SERVER_URL: "http://localhost/server"
+          BEHAT_FILTER_TAGS: ""
+        run: |
+          cd apps/${{ inputs.app-name }}
+          make test-acceptance-api
+
+      - name: Run CLI acceptance tests
+        if: ${{ inputs.do-cli-tests }}
+        env:
+          TEST_SERVER_URL: "http://localhost/server"
+          BEHAT_FILTER_TAGS: ""
+        run: |
+          cd apps/${{ inputs.app-name }}
+          make test-acceptance-cli
+
+      - name: Run WebUI acceptance tests
+        if: ${{ inputs.do-webui-tests }}
+        env:
+          TEST_SERVER_URL: "http://localhost/server"
+          BROWSER: "chrome"
+          SELENIUM_HOST: "localhost"
+          SELENIUM_PORT: "4444"
+          BEHAT_FILTER_TAGS: ""
+        run: |
+          cd apps/${{ inputs.app-name }}
+          make test-acceptance-webui
+
+      - name: Display log file
+        if: failure()
+        run: |
+          sudo -u www-data ls -l /var/www/html/server
+          sudo -u www-data ls -l /var/www/html/server/data
+          sudo -u www-data cat /var/www/html/server/data/owncloud.log

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -15,8 +15,18 @@ on:
         required: false
         type: string
         default: '["mariadb:10.6"]'
+      test-suites:
+        description: JSON array of acceptance test suite names
+        required: false
+        type: string
+        default: '[""]'
       app-repository:
         description: 'Repository of the app (optional, defaults to the current repository)'
+        required: false
+        type: string
+        default: ''
+      server-root:
+        description: 'The folder under the Apache root in which to install owncloud core'
         required: false
         type: string
         default: ''
@@ -60,6 +70,7 @@ jobs:
       matrix:
         php: ${{ fromJSON(inputs.php-versions) }}
         database: ${{ fromJSON(inputs.databases) }}
+        suite: ${{ fromJSON(inputs.test-suites) }}
 
     services:
       mysql:
@@ -132,9 +143,12 @@ jobs:
       - name: Check Apache server status
         run: curl http://localhost:80
 
+      - name: Delete default Apache server html files
+        run: sudo rm -Rf /var/www/html/*
+
       - name: Install owncloud/core
         run: |
-          docker run -v /var/www/html:/var/www/html \
+          docker run -v /var/www/html${{ inputs.server-root }}:/var/www/html${{ inputs.server-root }} \
             --network=host \
             -e PLUGIN_VERSION=${VERSION} \
             -e PLUGIN_CORE_PATH=${CORE_PATH} \
@@ -146,7 +160,7 @@ jobs:
             owncloudci/core:php83
         env:
           VERSION: 'daily-master-qa'
-          CORE_PATH: '/var/www/html/server'
+          CORE_PATH: /var/www/html${{ inputs.server-root }}
           DB_TYPE: 'mysql'
           DB_NAME: 'owncloud'
           DB_HOST: '127.0.0.1'
@@ -155,8 +169,8 @@ jobs:
 
       - name: Setup permissions for the backend of the Apache server
         run: |
-          sudo chown -R www-data:www-data /var/www/html/server
-          sudo chmod -R 777 /var/www/html/server
+          sudo chown -R www-data:www-data /var/www/html${{ inputs.server-root }}
+          sudo chmod -R 777 /var/www/html${{ inputs.server-root }}
 
       - name: Selenium
         if: ${{ inputs.do-webui-tests }}
@@ -173,24 +187,24 @@ jobs:
         run: |
           cd apps/${{ inputs.app-name }}
           make ci
-          sudo -u www-data mkdir /var/www/html/server/apps/${{ inputs.app-name }}
-          sudo -u www-data cp -r * /var/www/html/server/apps/${{ inputs.app-name }}
-          cd /var/www/html/server
+          sudo -u www-data mkdir /var/www/html${{ inputs.server-root }}/apps/${{ inputs.app-name }}
+          sudo -u www-data cp -r * /var/www/html${{ inputs.server-root }}/apps/${{ inputs.app-name }}
+          cd /var/www/html${{ inputs.server-root }}
           sudo -u www-data php occ a:e ${{ inputs.app-name }}
 
-      - name: Setup additional app ${{ inputs.app-name }}
+      - name: Setup additional app ${{ inputs.additional-app }}
         if: ${{ inputs.additional-app != '' }}
         run: |
           cd apps/${{ inputs.additional-app }}
           make ci
-          sudo -u www-data mkdir /var/www/html/server/apps/${{ inputs.additional-app }}
-          sudo -u www-data cp -r * /var/www/html/server/apps/${{ inputs.additional-app }}
-          cd /var/www/html/server
+          sudo -u www-data mkdir /var/www/html${{ inputs.server-root }}/apps/${{ inputs.additional-app }}
+          sudo -u www-data cp -r * /var/www/html${{ inputs.server-root }}/apps/${{ inputs.additional-app }}
+          cd /var/www/html${{ inputs.server-root }}
           sudo -u www-data php occ a:e ${{ inputs.additional-app }}
 
       - name: Setup owncloud server settings
         run: |
-          cd /var/www/html/server
+          cd /var/www/html${{ inputs.server-root }}
           sudo -u www-data php occ config:system:set trusted_domains 1 --value=localhost
           sudo -u www-data php occ log:manage --level 2
           sudo -u www-data php occ config:system:set csrf.disabled --value=true
@@ -198,7 +212,7 @@ jobs:
           sudo -u www-data php occ a:l -e
 
       - name: Check access to status
-        run: curl http://localhost:80/server/status.php
+        run: curl http://localhost:80${{ inputs.server-root }}/status.php
 
       - name: Install libxml2-utils to get xmllint used by acceptance test script
         run: sudo apt install -y libxml2-utils
@@ -206,7 +220,8 @@ jobs:
       - name: Run API acceptance tests
         if: ${{ inputs.do-api-tests }}
         env:
-          TEST_SERVER_URL: "http://localhost/server"
+          TEST_SERVER_URL: http://localhost${{ inputs.server-root }}
+          BEHAT_SUITE: ${{ matrix.suite }}
           BEHAT_FILTER_TAGS: ""
         run: |
           cd apps/${{ inputs.app-name }}
@@ -215,7 +230,8 @@ jobs:
       - name: Run CLI acceptance tests
         if: ${{ inputs.do-cli-tests }}
         env:
-          TEST_SERVER_URL: "http://localhost/server"
+          TEST_SERVER_URL: http://localhost${{ inputs.server-root }}
+          BEHAT_SUITE: ${{ matrix.suite }}
           BEHAT_FILTER_TAGS: ""
         run: |
           cd apps/${{ inputs.app-name }}
@@ -224,10 +240,11 @@ jobs:
       - name: Run WebUI acceptance tests
         if: ${{ inputs.do-webui-tests }}
         env:
-          TEST_SERVER_URL: "http://localhost/server"
+          TEST_SERVER_URL: http://localhost${{ inputs.server-root }}
           BROWSER: "chrome"
           SELENIUM_HOST: "localhost"
           SELENIUM_PORT: "4444"
+          BEHAT_SUITE: ${{ matrix.suite }}
           BEHAT_FILTER_TAGS: ""
         run: |
           cd apps/${{ inputs.app-name }}
@@ -236,6 +253,6 @@ jobs:
       - name: Display log file
         if: failure()
         run: |
-          sudo -u www-data ls -l /var/www/html/server
-          sudo -u www-data ls -l /var/www/html/server/data
-          sudo -u www-data cat /var/www/html/server/data/owncloud.log
+          sudo -u www-data ls -l /var/www/html${{ inputs.server-root }}
+          sudo -u www-data ls -l /var/www/html${{ inputs.server-root }}/data
+          sudo -u www-data cat /var/www/html${{ inputs.server-root }}/data/owncloud.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,21 @@ jobs:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-versions: ${{ needs.get-vars.outputs.php-versions }}
 
+  acceptance-api:
+    name: API acceptance tests
+    needs:
+      - get-vars
+    uses: ./.github/workflows/acceptance.yml
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-api-tests: true
+
+  acceptance-webui:
+    name: WebUI acceptance tests
+    needs:
+      - get-vars
+    uses: ./.github/workflows/acceptance.yml
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       do-api-tests: true
+      server-root: '/server'
 
   acceptance-webui:
     name: WebUI acceptance tests
@@ -72,4 +73,5 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       do-webui-tests: true
+      server-root: '/server'
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ dist: build-dep js-templates build-src
 %.js: $(template_src)
 		$(HANDLEBARS) -n "$(js_namespace)" $* -f $@
 
+# Installs dependencies and does any build actions needed for the app to run in CI
+.PHONY: ci
+ci: vendor build-dep js-templates
+	@echo dependencies and build actions for CI are completed
+
 .PHONY: build-dep
 build-dep: ## fetch all dependencies
 build-dep: node_modules


### PR DESCRIPTION
This is a first part of what will be needed:

- run an Apache server
- use owncloudci/core docker image (in an action) to install owncloud core from a tarball (daily-master-qa)
- copy the app code into the installed core
- enable the app
- get an environment set up that has the test code (acceptance test code from core, and for the app)
- run API test scenarios
- start selenium and other pieces started to support webUI tests
- run webui test scenarios

Next:
- write notes about what I have done
- use this is another app, and see what extra flexibility is needed