### PR TITLE
chore(ci): add a ci target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ dist: build-dep js-templates build-src
 %.js: $(template_src)
 		$(HANDLEBARS) -n "$(js_namespace)" $* -f $@
 
+# Installs dependencies and does any build actions needed for the app to run in CI
+.PHONY: ci
+ci: vendor build-dep js-templates
+	@echo dependencies and build actions for CI are completed
+
 .PHONY: build-dep
 build-dep: ## fetch all dependencies
 build-dep: node_modules


### PR DESCRIPTION
The "ci" target specifies the actions needed after checking out the repository, to then have the app in a state where it can be enabled and functional "in place", so that any acceptance test should pass.

For the impersonate app, that requires:
- install the PHP composer dependencies
- install the various JS dependencies from package.json
- build the JS templates

Then the acceptance reusable workflow can "make ci" for any app.